### PR TITLE
Creating log definitions for Push feature initialization

### DIFF
--- a/__tests__/example.test.js
+++ b/__tests__/example.test.js
@@ -1,5 +1,0 @@
-describe("Example test so jest doesn't fail", () => {
-  test("should pass trivially", () => {
-    expect(true).toBe(true);
-  });
-});

--- a/__tests__/push-init.test.js
+++ b/__tests__/push-init.test.js
@@ -1,0 +1,53 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Push notifications init flow', () => {
+  const filePath = path.resolve(__dirname, '../generated/json/push/push-init.json');
+  let data;
+
+  test('should be valid JSON', () => {
+    const fileContent = fs.readFileSync(filePath, 'utf-8');
+    expect(() => {
+      data = JSON.parse(fileContent);
+    }).not.toThrow();
+  });
+
+  describe('Parsed JSON structure', () => {
+    beforeAll(() => {
+      const fileContent = fs.readFileSync(filePath, 'utf-8');
+      data = JSON.parse(fileContent);
+    });
+
+    test('should contain the correct event IDs in order', () => {
+      const actualIds = data.map(event => event.id);
+      const expectedIds = [
+        "core-sdk-init",
+        "core-sdk-init-already-initialized",
+        "data-pipelines-module-init",
+        "data-pipelines-module-success",
+        "push-module-init",
+        "push-google-services-available",
+        "push-google-services-error",
+        "push-module-success",
+        "core-sdk-init-success"
+      ];
+  
+      expect(actualIds).toEqual(expectedIds);
+    });
+
+    test('event IDs should be unique', () => {
+      const ids = data.map(event => event.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    test('each event should have required keys for its ID', () => {
+      data.forEach(event => {
+        expect(event).toHaveProperty('id');
+        expect(event).toHaveProperty('label');
+        expect(event).toHaveProperty('log');
+        expect(event).toHaveProperty('tag');
+      });
+    });
+  });
+});

--- a/__tests__/push-init.test.js
+++ b/__tests__/push-init.test.js
@@ -49,5 +49,49 @@ describe('Push notifications init flow', () => {
         expect(event).toHaveProperty('tag');
       });
     });
+
+    test('event "core-sdk-init" has correct link values', () => {
+      const event = data.find(e => e.id === 'core-sdk-init');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('error', 'core-sdk-init-already-initialized');
+      expect(event).toHaveProperty('next', 'data-pipelines-module-init');
+    });
+
+    test('event "data-pipelines-module-init" has correct link values', () => {
+      const event = data.find(e => e.id === 'data-pipelines-module-init');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('success', 'data-pipelines-module-success');
+    });
+
+    test('event "data-pipelines-module-success" has correct link values', () => {
+      const event = data.find(e => e.id === 'data-pipelines-module-success');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('next', 'push-module-init');
+    });
+
+    test('event "push-module-init" has correct link values', () => {
+      const event = data.find(e => e.id === 'push-module-init');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('next', 'push-google-services-available');
+    });
+
+    test('event "push-google-services-available" has correct link values', () => {
+      const event = data.find(e => e.id === 'push-google-services-available');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('next', 'push-module-success');
+      expect(event).toHaveProperty('error', 'push-google-services-error');
+    });
+
+    test('event "push-module-success" has correct link values', () => {
+      const event = data.find(e => e.id === 'push-module-success');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('next', 'core-sdk-init-success');
+    });
   });
 });

--- a/features/push/push-init.jsonnet
+++ b/features/push/push-init.jsonnet
@@ -1,0 +1,73 @@
+local tags = import '../tags.libsonnet';
+
+[
+  // Core SDK init
+  {
+    id: 'core-sdk-init',
+    label: 'Initializing core SDK',
+    tag: tags.initTag,
+    log: 'Creating new instance of CustomerIO SDK version: {{version}}...',
+    next: 'data-pipelines-module-init',
+    'error': 'core-sdk-init-already-initialized',
+  },
+  {
+    id: 'core-sdk-init-already-initialized',
+    label: 'Core SDK already initialized',
+    tag: tags.initTag,
+    log: 'CustomerIO instance is already initialized, skipping the initialization',
+  },
+
+  // DataPipelines init
+  {
+    id: 'data-pipelines-module-init',
+    label: 'Initializing DataPipelines module',
+    tag: tags.initTag,
+    log: 'Initializing SDK module DataPipelines with config: {{config}}',
+    success: 'data-pipelines-module-success',
+  },
+  {
+    id: 'data-pipelines-module-success',
+    label: 'DataPipelines module init success',
+    tag: tags.initTag,
+    log: 'CustomerIO DataPipelines module is initialized and ready to use',
+    next: 'push-module-init',
+  },
+
+  // Push init
+  {
+    id: 'push-module-init',
+    label: 'Initializing Push module',
+    tag: tags.initTag,
+    log: 'Initializing SDK module MessagingPushFCM with config: {{config}}',
+    next: 'push-google-services-available',
+  },
+  {
+    id: 'push-google-services-available',
+    label: 'Google Services available (Android only)',
+    tag: tags.pushTag,
+    log: 'Google Play Services is available for this device',
+    next: 'push-module-success',
+    'error': 'push-google-services-error',
+  },
+  {
+    id: 'push-google-services-error',
+    label: 'Google Services NOT available (Android only)',
+    tag: tags.pushTag,
+    log: 'Google Play Services is NOT available for this device with result: {{result}}',
+  },
+  {
+    id: 'push-module-success',
+    label: 'Push module init success',
+    tag: tags.initTag,
+    log: 'CustomerIO MessagingPushFCM module is initialized and ready to use',
+    next: 'core-sdk-init-success',
+  },
+
+
+  {
+    id: 'core-sdk-init-success',
+    label: 'Core SDK init success',
+    tag: tags.initTag,
+    log: 'CustomerIO SDK is initialized and ready to use',
+  }
+]

--- a/features/tags.libsonnet
+++ b/features/tags.libsonnet
@@ -1,0 +1,4 @@
+{
+  initTag: "Init",
+  pushTag: "Push"
+}

--- a/generated/json/push/push-init.json
+++ b/generated/json/push/push-init.json
@@ -1,0 +1,64 @@
+[
+   {
+      "error": "core-sdk-init-already-initialized",
+      "id": "core-sdk-init",
+      "label": "Initializing core SDK",
+      "log": "Creating new instance of CustomerIO SDK version: {{version}}...",
+      "next": "data-pipelines-module-init",
+      "tag": "Init"
+   },
+   {
+      "id": "core-sdk-init-already-initialized",
+      "label": "Core SDK already initialized",
+      "log": "CustomerIO instance is already initialized, skipping the initialization",
+      "tag": "Init"
+   },
+   {
+      "id": "data-pipelines-module-init",
+      "label": "Initializing DataPipelines module",
+      "log": "Initializing SDK module DataPipelines with config: {{config}}",
+      "success": "data-pipelines-module-success",
+      "tag": "Init"
+   },
+   {
+      "id": "data-pipelines-module-success",
+      "label": "DataPipelines module init success",
+      "log": "CustomerIO DataPipelines module is initialized and ready to use",
+      "next": "push-module-init",
+      "tag": "Init"
+   },
+   {
+      "id": "push-module-init",
+      "label": "Initializing Push module",
+      "log": "Initializing SDK module MessagingPushFCM with config: {{config}}",
+      "next": "push-google-services-available",
+      "tag": "Init"
+   },
+   {
+      "error": "push-google-services-error",
+      "id": "push-google-services-available",
+      "label": "Google Services available (Android only)",
+      "log": "Google Play Services is available for this device",
+      "next": "push-module-success",
+      "tag": "Push"
+   },
+   {
+      "id": "push-google-services-error",
+      "label": "Google Services NOT available (Android only)",
+      "log": "Google Play Services is NOT available for this device with result: {{result}}",
+      "tag": "Push"
+   },
+   {
+      "id": "push-module-success",
+      "label": "Push module init success",
+      "log": "CustomerIO MessagingPushFCM module is initialized and ready to use",
+      "next": "core-sdk-init-success",
+      "tag": "Init"
+   },
+   {
+      "id": "core-sdk-init-success",
+      "label": "Core SDK init success",
+      "log": "CustomerIO SDK is initialized and ready to use",
+      "tag": "Init"
+   }
+]

--- a/generated/mermaid/push/push-init.mmd
+++ b/generated/mermaid/push/push-init.mmd
@@ -1,0 +1,18 @@
+graph TD
+core-sdk-init["Initializing core SDK"]
+core-sdk-init --> data-pipelines-module-init
+core-sdk-init -->|Error| core-sdk-init-already-initialized
+core-sdk-init-already-initialized["Core SDK already initialized"]
+data-pipelines-module-init["Initializing DataPipelines module"]
+data-pipelines-module-init -->|Success| data-pipelines-module-success
+data-pipelines-module-success["DataPipelines module init success"]
+data-pipelines-module-success --> push-module-init
+push-module-init["Initializing Push module"]
+push-module-init --> push-google-services-available
+push-google-services-available["Google Services available (Android only)"]
+push-google-services-available --> push-module-success
+push-google-services-available -->|Error| push-google-services-error
+push-google-services-error["Google Services NOT available (Android only)"]
+push-module-success["Push module init success"]
+push-module-success --> core-sdk-init-success
+core-sdk-init-success["Core SDK init success"]


### PR DESCRIPTION
Part of: [MBL-1075](https://linear.app/customerio/issue/MBL-1075/update-push-notifications-logging-for-android)

### Overview
This PR creates the logs definitions for the `initialization` part of the push logs defined [here](https://www.notion.so/custio/Consolidated-Push-Notification-logs-1de4302f4c2b807da5bdfb4aa1f62e5c?pvs=4#1de4302f4c2b8061b256df94139ea6ed)

- Generates JSON for the events
- Generates Mermaid diagram

Implementation PRs:
- https://github.com/customerio/customerio-android/pull/530
- https://github.com/customerio/customerio-ios/pull/894

### Test
Added unit test for the those events

### Generated diagram
```mermaid
graph TD
core-sdk-init["Initializing core SDK"]
core-sdk-init --> data-pipelines-module-init
core-sdk-init -->|Error| core-sdk-init-already-initialized
core-sdk-init-already-initialized["Core SDK already initialized"]
data-pipelines-module-init["Initializing DataPipelines module"]
data-pipelines-module-init -->|Success| data-pipelines-module-success
data-pipelines-module-success["DataPipelines module init success"]
data-pipelines-module-success --> push-module-init
push-module-init["Initializing Push module"]
push-module-init --> push-google-services-available
push-google-services-available["Google Services available (Android only)"]
push-google-services-available --> push-module-success
push-google-services-available -->|Error| push-google-services-error
push-google-services-error["Google Services NOT available (Android only)"]
push-module-success["Push module init success"]
push-module-success --> core-sdk-init-success
core-sdk-init-success["Core SDK init success"]
```