### PR TITLE
Creating log defintions for push token setup

### DIFF
--- a/__tests__/push-init.test.js
+++ b/__tests__/push-init.test.js
@@ -26,10 +26,15 @@ describe('Push notifications init flow', () => {
         "data-pipelines-module-init",
         "data-pipelines-module-success",
         "push-module-init",
+        "pulling-current-push-token",
+        "pulling-current-push-token-failed",
         "push-google-services-available",
         "push-google-services-error",
         "push-module-success",
-        "core-sdk-init-success"
+        "core-sdk-init-success",
+        "pulled-current-push-token",
+        "storing-push-token",
+        "registering-push-token",
       ];
   
       expect(actualIds).toEqual(expectedIds);
@@ -76,7 +81,15 @@ describe('Push notifications init flow', () => {
       const event = data.find(e => e.id === 'push-module-init');
       expect(event).toBeDefined();
   
+      expect(event).toHaveProperty('next', 'pulling-current-push-token');
+    });
+
+    test('event "pulling-current-push-token" has correct link values', () => {
+      const event = data.find(e => e.id === 'pulling-current-push-token');
+      expect(event).toBeDefined();
+  
       expect(event).toHaveProperty('next', 'push-google-services-available');
+      expect(event).toHaveProperty('error', 'pulling-current-push-token-failed');
     });
 
     test('event "push-google-services-available" has correct link values', () => {
@@ -92,6 +105,27 @@ describe('Push notifications init flow', () => {
       expect(event).toBeDefined();
   
       expect(event).toHaveProperty('next', 'core-sdk-init-success');
+    });
+
+    test('event "core-sdk-init-success" has correct link values', () => {
+      const event = data.find(e => e.id === 'core-sdk-init-success');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('next', 'pulled-current-push-token');
+    });
+
+    test('event "pulled-current-push-token" has correct link values', () => {
+      const event = data.find(e => e.id === 'pulled-current-push-token');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('next', 'storing-push-token');
+    });
+
+    test('event "storing-push-token" has correct link values', () => {
+      const event = data.find(e => e.id === 'storing-push-token');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('next', 'registering-push-token');
     });
   });
 });

--- a/features/push/push-init.jsonnet
+++ b/features/push/push-init.jsonnet
@@ -39,7 +39,21 @@ local tags = import '../tags.libsonnet';
     label: 'Initializing Push module',
     tag: tags.initTag,
     log: 'Initializing SDK module MessagingPushFCM with config: {{config}}',
+    next: 'pulling-current-push-token',
+  },
+  {
+    id: 'pulling-current-push-token',
+    label: 'Pull push token (Android only)',
+    tag: tags.pushTag,
+    log: 'Getting current device token from Firebase messaging on app launch',
     next: 'push-google-services-available',
+    'error': 'pulling-current-push-token-failed',
+  },
+  {
+    id: 'pulling-current-push-token-failed',
+    label: 'Pull push token failed (Android only)',
+    tag: tags.pushTag,
+    log: 'Failed to get device token with error: {{errorMessage}}',
   },
   {
     id: 'push-google-services-available',
@@ -69,5 +83,28 @@ local tags = import '../tags.libsonnet';
     label: 'Core SDK init success',
     tag: tags.initTag,
     log: 'CustomerIO SDK is initialized and ready to use',
+    next: 'pulled-current-push-token'
+  },
+
+  // Push token setup
+  {
+    id: 'pulled-current-push-token',
+    label: 'Obtained current device token (Android only)',
+    tag: tags.pushTag,
+    log: 'Got current device token: {{token}}',
+    next: 'storing-push-token'
+  },
+  {
+    id: 'storing-push-token',
+    label: 'Storing device token',
+    tag: tags.pushTag,
+    log: 'Storing device token: {{token}}',
+    next: 'registering-push-token'
+  },
+  {
+    id: 'registering-push-token',
+    label: 'Obtained current device token',
+    tag: tags.pushTag,
+    log: 'Registering device token: {{token}}',
   }
 ]

--- a/features/push/push-init.jsonnet
+++ b/features/push/push-init.jsonnet
@@ -103,7 +103,7 @@ local tags = import '../tags.libsonnet';
   },
   {
     id: 'registering-push-token',
-    label: 'Obtained current device token',
+    label: 'Registering device token',
     tag: tags.pushTag,
     log: 'Registering device token: {{token}}',
   }

--- a/generated/json/push/push-init.json
+++ b/generated/json/push/push-init.json
@@ -31,8 +31,22 @@
       "id": "push-module-init",
       "label": "Initializing Push module",
       "log": "Initializing SDK module MessagingPushFCM with config: {{config}}",
-      "next": "push-google-services-available",
+      "next": "pulling-current-push-token",
       "tag": "Init"
+   },
+   {
+      "error": "pulling-current-push-token-failed",
+      "id": "pulling-current-push-token",
+      "label": "Pull push token (Android only)",
+      "log": "Getting current device token from Firebase messaging on app launch",
+      "next": "push-google-services-available",
+      "tag": "Push"
+   },
+   {
+      "id": "pulling-current-push-token-failed",
+      "label": "Pull push token failed (Android only)",
+      "log": "Failed to get device token with error: {{errorMessage}}",
+      "tag": "Push"
    },
    {
       "error": "push-google-services-error",
@@ -59,6 +73,27 @@
       "id": "core-sdk-init-success",
       "label": "Core SDK init success",
       "log": "CustomerIO SDK is initialized and ready to use",
+      "next": "pulled-current-push-token",
       "tag": "Init"
+   },
+   {
+      "id": "pulled-current-push-token",
+      "label": "Obtained current device token (Android only)",
+      "log": "Got current device token: {{token}}",
+      "next": "storing-push-token",
+      "tag": "Push"
+   },
+   {
+      "id": "storing-push-token",
+      "label": "Storing device token",
+      "log": "Storing device token: {{token}}",
+      "next": "registering-push-token",
+      "tag": "Push"
+   },
+   {
+      "id": "registering-push-token",
+      "label": "Obtained current device token",
+      "log": "Registering device token: {{token}}",
+      "tag": "Push"
    }
 ]

--- a/generated/mermaid/push/push-init.mmd
+++ b/generated/mermaid/push/push-init.mmd
@@ -8,7 +8,11 @@ data-pipelines-module-init -->|Success| data-pipelines-module-success
 data-pipelines-module-success["DataPipelines module init success"]
 data-pipelines-module-success --> push-module-init
 push-module-init["Initializing Push module"]
-push-module-init --> push-google-services-available
+push-module-init --> pulling-current-push-token
+pulling-current-push-token["Pull push token (Android only)"]
+pulling-current-push-token --> push-google-services-available
+pulling-current-push-token -->|Error| pulling-current-push-token-failed
+pulling-current-push-token-failed["Pull push token failed (Android only)"]
 push-google-services-available["Google Services available (Android only)"]
 push-google-services-available --> push-module-success
 push-google-services-available -->|Error| push-google-services-error
@@ -16,3 +20,9 @@ push-google-services-error["Google Services NOT available (Android only)"]
 push-module-success["Push module init success"]
 push-module-success --> core-sdk-init-success
 core-sdk-init-success["Core SDK init success"]
+core-sdk-init-success --> pulled-current-push-token
+pulled-current-push-token["Obtained current device token (Android only)"]
+pulled-current-push-token --> storing-push-token
+storing-push-token["Storing device token"]
+storing-push-token --> registering-push-token
+registering-push-token["Obtained current device token"]


### PR DESCRIPTION
Part of: [MBL-1111](https://linear.app/customerio/issue/MBL-1111/update-push-notification-setup-logs) & [MBL-1118](https://linear.app/customerio/issue/MBL-1118/update-push-notification-setup-logs)

### Overview
This PR creates the logs definitions for the `Push notifications setup` part of the push logs defined [here](https://www.notion.so/custio/Consolidated-Push-Notification-logs-1de4302f4c2b807da5bdfb4aa1f62e5c?pvs=4#1de4302f4c2b8090841fc8aa766a9624)

- Generates JSON for the events
- Generates Mermaid diagram

Implementation PRs:
- https://github.com/customerio/customerio-android/pull/534
- https://github.com/customerio/customerio-ios/pull/895

### Test plan
Added unit test for the those events

### Generated diagram
```mermaid
graph TD
core-sdk-init["Initializing core SDK"]
core-sdk-init --> data-pipelines-module-init
core-sdk-init -->|Error| core-sdk-init-already-initialized
core-sdk-init-already-initialized["Core SDK already initialized"]
data-pipelines-module-init["Initializing DataPipelines module"]
data-pipelines-module-init -->|Success| data-pipelines-module-success
data-pipelines-module-success["DataPipelines module init success"]
data-pipelines-module-success --> push-module-init
push-module-init["Initializing Push module"]
push-module-init --> pulling-current-push-token
pulling-current-push-token["Pull push token (Android only)"]
pulling-current-push-token --> push-google-services-available
pulling-current-push-token -->|Error| pulling-current-push-token-failed
pulling-current-push-token-failed["Pull push token failed (Android only)"]
push-google-services-available["Google Services available (Android only)"]
push-google-services-available --> push-module-success
push-google-services-available -->|Error| push-google-services-error
push-google-services-error["Google Services NOT available (Android only)"]
push-module-success["Push module init success"]
push-module-success --> core-sdk-init-success
core-sdk-init-success["Core SDK init success"]
core-sdk-init-success --> pulled-current-push-token
pulled-current-push-token["Obtained current device token (Android only)"]
pulled-current-push-token --> storing-push-token
storing-push-token["Storing device token"]
storing-push-token --> registering-push-token
registering-push-token["Obtained current device token"]
```
