### PR TITLE
Create identify logs related to push notifications

### DIFF
--- a/__tests__/push-init.test.js
+++ b/__tests__/push-init.test.js
@@ -35,6 +35,8 @@ describe('Push notifications init flow', () => {
         "pulled-current-push-token",
         "storing-push-token",
         "registering-push-token",
+        "automatic-profile-push-token-registration",
+        "show-push-notification"
       ];
   
       expect(actualIds).toEqual(expectedIds);
@@ -126,6 +128,20 @@ describe('Push notifications init flow', () => {
       expect(event).toBeDefined();
   
       expect(event).toHaveProperty('next', 'registering-push-token');
+    });
+
+    test('event "registering-push-token" has correct link values', () => {
+      const event = data.find(e => e.id === 'registering-push-token');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('next', 'automatic-profile-push-token-registration');
+    });
+
+    test('event "automatic-profile-push-token-registration" has correct link values', () => {
+      const event = data.find(e => e.id === 'automatic-profile-push-token-registration');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('next', 'show-push-notification');
     });
   });
 });

--- a/features/push/push-init.jsonnet
+++ b/features/push/push-init.jsonnet
@@ -106,5 +106,20 @@ local tags = import '../tags.libsonnet';
     label: 'Registering device token',
     tag: tags.pushTag,
     log: 'Registering device token: {{token}}',
+    next: 'automatic-profile-push-token-registration'
+  },
+
+  {
+    id: 'automatic-profile-push-token-registration',
+    label: 'Automatically registering token to profile',
+    tag: tags.pushTag,
+    log: 'Automatically registering device token: {{token}} to newly identified profile: {{userId}}',
+    next: 'show-push-notification'
+  },
+  {
+    id: 'show-push-notification',
+    label: 'Showing push notification (Android only)',
+    tag: tags.pushTag,
+    log: 'Showing notification for message: {{message}}',
   }
 ]

--- a/generated/json/push/push-init.json
+++ b/generated/json/push/push-init.json
@@ -92,8 +92,22 @@
    },
    {
       "id": "registering-push-token",
-      "label": "Obtained current device token",
+      "label": "Registering device token",
       "log": "Registering device token: {{token}}",
+      "next": "automatic-profile-push-token-registration",
+      "tag": "Push"
+   },
+   {
+      "id": "automatic-profile-push-token-registration",
+      "label": "Automatically registering token to profile",
+      "log": "Automatically registering device token: {{token}} to newly identified profile: {{userId}}",
+      "next": "show-push-notification",
+      "tag": "Push"
+   },
+   {
+      "id": "show-push-notification",
+      "label": "Showing push notification (Android only)",
+      "log": "Showing notification for message: {{message}}",
       "tag": "Push"
    }
 ]

--- a/generated/mermaid/push/push-init.mmd
+++ b/generated/mermaid/push/push-init.mmd
@@ -25,4 +25,8 @@ pulled-current-push-token["Obtained current device token (Android only)"]
 pulled-current-push-token --> storing-push-token
 storing-push-token["Storing device token"]
 storing-push-token --> registering-push-token
-registering-push-token["Obtained current device token"]
+registering-push-token["Registering device token"]
+registering-push-token --> automatic-profile-push-token-registration
+automatic-profile-push-token-registration["Automatically registering token to profile"]
+automatic-profile-push-token-registration --> show-push-notification
+show-push-notification["Showing push notification (Android only)"]


### PR DESCRIPTION
Part of: [MBL-1112](https://linear.app/customerio/issue/MBL-1112/update-identify-logs) & [MBL-1119](https://linear.app/customerio/issue/MBL-1119/update-identify-logs)

### Overview
This PR creates the logs definitions for the `Identify` part of the push logs defined [here](https://www.notion.so/custio/Consolidated-Push-Notification-logs-1de4302f4c2b807da5bdfb4aa1f62e5c?pvs=4#1de4302f4c2b804a974ce82be709bdeb)

- Generates JSON for the events
- Generates Mermaid diagram

Implementation PRs:
- https://github.com/customerio/customerio-android/pull/538
- https://github.com/customerio/customerio-ios/pull/898

### Test plan
Added unit test for the those events

### Generated diagram
```mermaid
graph TD
core-sdk-init["Initializing core SDK"]
core-sdk-init --> data-pipelines-module-init
core-sdk-init -->|Error| core-sdk-init-already-initialized
core-sdk-init-already-initialized["Core SDK already initialized"]
data-pipelines-module-init["Initializing DataPipelines module"]
data-pipelines-module-init -->|Success| data-pipelines-module-success
data-pipelines-module-success["DataPipelines module init success"]
data-pipelines-module-success --> push-module-init
push-module-init["Initializing Push module"]
push-module-init --> pulling-current-push-token
pulling-current-push-token["Pull push token (Android only)"]
pulling-current-push-token --> push-google-services-available
pulling-current-push-token -->|Error| pulling-current-push-token-failed
pulling-current-push-token-failed["Pull push token failed (Android only)"]
push-google-services-available["Google Services available (Android only)"]
push-google-services-available --> push-module-success
push-google-services-available -->|Error| push-google-services-error
push-google-services-error["Google Services NOT available (Android only)"]
push-module-success["Push module init success"]
push-module-success --> core-sdk-init-success
core-sdk-init-success["Core SDK init success"]
core-sdk-init-success --> pulled-current-push-token
pulled-current-push-token["Obtained current device token (Android only)"]
pulled-current-push-token --> storing-push-token
storing-push-token["Storing device token"]
storing-push-token --> registering-push-token
registering-push-token["Registering device token"]
registering-push-token --> automatic-profile-push-token-registration
automatic-profile-push-token-registration["Automatically registering token to profile"]
automatic-profile-push-token-registration --> show-push-notification
show-push-notification["Showing push notification (Android only)"]
```
