### PR TITLE
Update logs for push notification delivery and opening

### DIFF
--- a/__tests__/push-init.test.js
+++ b/__tests__/push-init.test.js
@@ -36,7 +36,9 @@ describe('Push notifications init flow', () => {
         "storing-push-token",
         "registering-push-token",
         "automatic-profile-push-token-registration",
-        "show-push-notification"
+        "push-notification-delivered",
+        "show-push-notification",
+        "push-notification-opened"
       ];
   
       expect(actualIds).toEqual(expectedIds);
@@ -141,7 +143,21 @@ describe('Push notifications init flow', () => {
       const event = data.find(e => e.id === 'automatic-profile-push-token-registration');
       expect(event).toBeDefined();
   
+      expect(event).toHaveProperty('next', 'push-notification-delivered');
+    });
+
+    test('event "push-notification-delivered" has correct link values', () => {
+      const event = data.find(e => e.id === 'push-notification-delivered');
+      expect(event).toBeDefined();
+  
       expect(event).toHaveProperty('next', 'show-push-notification');
+    });
+
+    test('event "show-push-notification" has correct link values', () => {
+      const event = data.find(e => e.id === 'show-push-notification');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('next', 'push-notification-opened');
     });
   });
 });

--- a/features/push/push-init.jsonnet
+++ b/features/push/push-init.jsonnet
@@ -114,6 +114,13 @@ local tags = import '../tags.libsonnet';
     label: 'Automatically registering token to profile',
     tag: tags.pushTag,
     log: 'Automatically registering device token: {{token}} to newly identified profile: {{userId}}',
+    next: 'push-notification-delivered'
+  },
+  {
+    id: 'push-notification-delivered',
+    label: 'Push notification delivered',
+    tag: tags.pushTag,
+    log: 'Tracking push message delivered with deliveryId: {{deliveryId}}',
     next: 'show-push-notification'
   },
   {
@@ -121,5 +128,12 @@ local tags = import '../tags.libsonnet';
     label: 'Showing push notification (Android only)',
     tag: tags.pushTag,
     log: 'Showing notification for message: {{message}}',
+    next: "push-notification-opened"
+  },
+  {
+    id: 'push-notification-opened',
+    label: 'Push notification opened',
+    tag: tags.pushTag,
+    log: 'Tracking push message opened with payload: {{payload}}',
   }
 ]

--- a/generated/json/push/push-init.json
+++ b/generated/json/push/push-init.json
@@ -101,6 +101,13 @@
       "id": "automatic-profile-push-token-registration",
       "label": "Automatically registering token to profile",
       "log": "Automatically registering device token: {{token}} to newly identified profile: {{userId}}",
+      "next": "push-notification-delivered",
+      "tag": "Push"
+   },
+   {
+      "id": "push-notification-delivered",
+      "label": "Push notification delivered",
+      "log": "Tracking push message delivered with deliveryId: {{deliveryId}}",
       "next": "show-push-notification",
       "tag": "Push"
    },
@@ -108,6 +115,13 @@
       "id": "show-push-notification",
       "label": "Showing push notification (Android only)",
       "log": "Showing notification for message: {{message}}",
+      "next": "push-notification-opened",
+      "tag": "Push"
+   },
+   {
+      "id": "push-notification-opened",
+      "label": "Push notification opened",
+      "log": "Tracking push message opened with payload: {{payload}}",
       "tag": "Push"
    }
 ]

--- a/generated/mermaid/push/push-init.mmd
+++ b/generated/mermaid/push/push-init.mmd
@@ -28,5 +28,9 @@ storing-push-token --> registering-push-token
 registering-push-token["Registering device token"]
 registering-push-token --> automatic-profile-push-token-registration
 automatic-profile-push-token-registration["Automatically registering token to profile"]
-automatic-profile-push-token-registration --> show-push-notification
+automatic-profile-push-token-registration --> push-notification-delivered
+push-notification-delivered["Push notification delivered"]
+push-notification-delivered --> show-push-notification
 show-push-notification["Showing push notification (Android only)"]
+show-push-notification --> push-notification-opened
+push-notification-opened["Push notification opened"]


### PR DESCRIPTION
Part of: [MBL-1121](https://linear.app/customerio/issue/MBL-1121/update-push-notification-click-handling-logs) & [MBL-1114](https://linear.app/customerio/issue/MBL-1114/update-push-notification-click-handling-logs)

### Overview
This PR creates the logs definitions for the `Push click handling and metrics tracking` part of the push logs defined [here](https://www.notion.so/custio/Consolidated-Push-Notification-logs-1de4302f4c2b807da5bdfb4aa1f62e5c)

- Generates JSON for the events
- Generates Mermaid diagram

Implementation PRs:
- https://github.com/customerio/customerio-android/pull/546
- https://github.com/customerio/customerio-ios/pull/916

### Test plan
Added unit test for the those events

### Generated diagram
```mermaid
graph TD
core-sdk-init["Initializing core SDK"]
core-sdk-init --> data-pipelines-module-init
core-sdk-init -->|Error| core-sdk-init-already-initialized
core-sdk-init-already-initialized["Core SDK already initialized"]
data-pipelines-module-init["Initializing DataPipelines module"]
data-pipelines-module-init -->|Success| data-pipelines-module-success
data-pipelines-module-success["DataPipelines module init success"]
data-pipelines-module-success --> push-module-init
push-module-init["Initializing Push module"]
push-module-init --> pulling-current-push-token
pulling-current-push-token["Pull push token (Android only)"]
pulling-current-push-token --> push-google-services-available
pulling-current-push-token -->|Error| pulling-current-push-token-failed
pulling-current-push-token-failed["Pull push token failed (Android only)"]
push-google-services-available["Google Services available (Android only)"]
push-google-services-available --> push-module-success
push-google-services-available -->|Error| push-google-services-error
push-google-services-error["Google Services NOT available (Android only)"]
push-module-success["Push module init success"]
push-module-success --> core-sdk-init-success
core-sdk-init-success["Core SDK init success"]
core-sdk-init-success --> pulled-current-push-token
pulled-current-push-token["Obtained current device token (Android only)"]
pulled-current-push-token --> storing-push-token
storing-push-token["Storing device token"]
storing-push-token --> registering-push-token
registering-push-token["Registering device token"]
registering-push-token --> automatic-profile-push-token-registration
automatic-profile-push-token-registration["Automatically registering token to profile"]
automatic-profile-push-token-registration --> push-notification-delivered
push-notification-delivered["Push notification delivered"]
push-notification-delivered --> show-push-notification
show-push-notification["Showing push notification (Android only)"]
show-push-notification --> push-notification-opened
push-notification-opened["Push notification opened"]
```
