### PR TITLE
Create logs for push deep linking

### DIFF
--- a/__tests__/deep-linking.test.js
+++ b/__tests__/deep-linking.test.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('Push deep linking flow', () => {
+  const filePath = path.resolve(__dirname, '../generated/json/push/deep-linking.json');
+  let data;
+
+  test('should be valid JSON', () => {
+    const fileContent = fs.readFileSync(filePath, 'utf-8');
+    expect(() => {
+      data = JSON.parse(fileContent);
+    }).not.toThrow();
+  });
+
+  describe('Parsed JSON structure', () => {
+    beforeAll(() => {
+      const fileContent = fs.readFileSync(filePath, 'utf-8');
+      data = JSON.parse(fileContent);
+    });
+
+    test('should contain the correct event IDs in order', () => {
+      const actualIds = data.map(event => event.id);
+      const expectedIds = [
+        "handling-push-deep-link-start",
+        "push-deep-link-not-handled",
+        "push-deep-link-handled-callback",
+        "push-deep-link-handled-host-app",
+        "push-deep-link-handled-externally"
+      ];
+  
+      expect(actualIds).toEqual(expectedIds);
+    });
+
+    test('event IDs should be unique', () => {
+      const ids = data.map(event => event.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    test('each event should have required keys for its ID', () => {
+      data.forEach(event => {
+        expect(event).toHaveProperty('id');
+        expect(event).toHaveProperty('label');
+        expect(event).toHaveProperty('log');
+        expect(event).toHaveProperty('tag');
+      });
+    });
+
+    test('event "handling-push-deep-link-start" has correct link values', () => {
+      const event = data.find(e => e.id === 'handling-push-deep-link-start');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('error', 'push-deep-link-not-handled');
+      expect(event).toHaveProperty('next', 'push-deep-link-handled-callback');
+    });
+
+    test('event "push-deep-link-handled-callback" has correct link values', () => {
+      const event = data.find(e => e.id === 'push-deep-link-handled-callback');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('next', 'push-deep-link-handled-host-app');
+    });
+
+    test('event "push-deep-link-handled-host-app" has correct link values', () => {
+      const event = data.find(e => e.id === 'push-deep-link-handled-host-app');
+      expect(event).toBeDefined();
+  
+      expect(event).toHaveProperty('next', 'push-deep-link-handled-externally');
+    });
+  });
+});

--- a/features/push/deep-linking.jsonnet
+++ b/features/push/deep-linking.jsonnet
@@ -5,7 +5,7 @@ local tags = import '../tags.libsonnet';
     id: 'handling-push-deep-link-start',
     label: 'Handling push deep linking',
     tag: tags.initTag,
-    log: 'Handling push notification deep link with payload: {payload} - pushClickBehavior: {behavior}',
+    log: 'Handling push notification deep link with payload: {payload}',
     next: 'push-deep-link-handled-callback',
     'error': 'push-deep-link-not-handled'
   },

--- a/features/push/deep-linking.jsonnet
+++ b/features/push/deep-linking.jsonnet
@@ -1,0 +1,38 @@
+local tags = import '../tags.libsonnet';
+
+[
+  {
+    id: 'handling-push-deep-link-start',
+    label: 'Handling push deep linking',
+    tag: tags.initTag,
+    log: 'Handling push notification deep link with payload: {payload} - pushClickBehavior: {behavior}',
+    next: 'push-deep-link-handled-callback',
+    'error': 'push-deep-link-not-handled'
+  },
+  {
+    id: 'push-deep-link-not-handled',
+    label: 'Push deep link not handled',
+    tag: tags.initTag,
+    log: 'Push notification deep link not handled'
+  },
+  {
+    id: 'push-deep-link-handled-callback',
+    label: 'Push deep link handled by host app callback',
+    tag: tags.initTag,
+    log: 'Deep link handled by host app callback implementation',
+    next: 'push-deep-link-handled-host-app'
+  },
+  {
+    id: 'push-deep-link-handled-host-app',
+    label: 'Push deep link handled by host app',
+    tag: tags.initTag,
+    log: 'Deep link handled by internal host app navigation',
+    next: 'push-deep-link-handled-externally'
+  },
+  {
+    id: 'push-deep-link-handled-externally',
+    label: 'Push deep link handled externally',
+    tag: tags.initTag,
+    log: 'Deep link handled by external app'
+  }
+]

--- a/generated/json/push/deep-linking.json
+++ b/generated/json/push/deep-linking.json
@@ -3,7 +3,7 @@
       "error": "push-deep-link-not-handled",
       "id": "handling-push-deep-link-start",
       "label": "Handling push deep linking",
-      "log": "Handling push notification deep link with payload: {payload} - pushClickBehavior: {behavior}",
+      "log": "Handling push notification deep link with payload: {payload}",
       "next": "push-deep-link-handled-callback",
       "tag": "Init"
    },

--- a/generated/json/push/deep-linking.json
+++ b/generated/json/push/deep-linking.json
@@ -1,0 +1,36 @@
+[
+   {
+      "error": "push-deep-link-not-handled",
+      "id": "handling-push-deep-link-start",
+      "label": "Handling push deep linking",
+      "log": "Handling push notification deep link with payload: {payload} - pushClickBehavior: {behavior}",
+      "next": "push-deep-link-handled-callback",
+      "tag": "Init"
+   },
+   {
+      "id": "push-deep-link-not-handled",
+      "label": "Push deep link not handled",
+      "log": "Push notification deep link not handled",
+      "tag": "Init"
+   },
+   {
+      "id": "push-deep-link-handled-callback",
+      "label": "Push deep link handled by host app callback",
+      "log": "Deep link handled by host app callback implementation",
+      "next": "push-deep-link-handled-host-app",
+      "tag": "Init"
+   },
+   {
+      "id": "push-deep-link-handled-host-app",
+      "label": "Push deep link handled by host app",
+      "log": "Deep link handled by internal host app navigation",
+      "next": "push-deep-link-handled-externally",
+      "tag": "Init"
+   },
+   {
+      "id": "push-deep-link-handled-externally",
+      "label": "Push deep link handled externally",
+      "log": "Deep link handled by external app",
+      "tag": "Init"
+   }
+]

--- a/generated/mermaid/push/deep-linking.mmd
+++ b/generated/mermaid/push/deep-linking.mmd
@@ -1,0 +1,10 @@
+graph TD
+handling-push-deep-link-start["Handling push deep linking"]
+handling-push-deep-link-start --> push-deep-link-handled-callback
+handling-push-deep-link-start -->|Error| push-deep-link-not-handled
+push-deep-link-not-handled["Push deep link not handled"]
+push-deep-link-handled-callback["Push deep link handled by host app callback"]
+push-deep-link-handled-callback --> push-deep-link-handled-host-app
+push-deep-link-handled-host-app["Push deep link handled by host app"]
+push-deep-link-handled-host-app --> push-deep-link-handled-externally
+push-deep-link-handled-externally["Push deep link handled externally"]


### PR DESCRIPTION
Part of: [MBL-1123](https://linear.app/customerio/issue/MBL-1123/update-push-notification-deep-linking-handling-logs) & [MBL-1116](https://linear.app/customerio/issue/MBL-1116/update-push-notification-deep-linking-handling-logs)

### Overview
This PR creates the logs definitions for the `Deep linking` part of the push logs defined [here](https://www.notion.so/custio/Consolidated-Push-Notification-logs-1de4302f4c2b807da5bdfb4aa1f62e5c?pvs=4#1de4302f4c2b80c8a064dc19cde9b74b)

- Generates JSON for the events
- Generates Mermaid diagram

Implementation PRs:
- https://github.com/customerio/customerio-android/pull/549
- https://github.com/customerio/customerio-ios/pull/917

### Test plan
Added unit test for the those events

### Generated diagram
```mermaid
graph TD
handling-push-deep-link-start["Handling push deep linking"]
handling-push-deep-link-start --> push-deep-link-handled-callback
handling-push-deep-link-start -->|Error| push-deep-link-not-handled
push-deep-link-not-handled["Push deep link not handled"]
push-deep-link-handled-callback["Push deep link handled by host app callback"]
push-deep-link-handled-callback --> push-deep-link-handled-host-app
push-deep-link-handled-host-app["Push deep link handled by host app"]
push-deep-link-handled-host-app --> push-deep-link-handled-externally
push-deep-link-handled-externally["Push deep link handled externally"]
```
